### PR TITLE
Use random passwords instead of predefined ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ To create a three node cluster that includes MySQL Router and MySQL Shell, and c
 
   ```./start_three_node_cluster.sh```
 
+Note: if you want to use a different image (for example when you have build a variant of the image locally,) you can run the following **before** invoking start_three_node_cluster.sh:
+
+  ```export INNODB_CLUSTER_IMG=your_username/innodb-cluster```
+
 #### Tear down (remove) a cluster
 
   ```./cleanup_cluster.sh```
@@ -35,6 +39,9 @@ This manual process essentially documents what the `start_three_node_cluster.sh`
   ```
 
 2. Bootstrap the cluster
+
+Note about the root password: A secure method in these examples uses a random password from a file. 
+Wherever the default password (_root_) is mentioned, use instead ```$(cat secretpassword.txt)```.
 
   ```
   docker run --name=mysqlgr1 --hostname=mysqlgr1 --network=grnet -e MYSQL_ROOT_PASSWORD=root -e BOOTSTRAP=1 -itd mattalord/innodb-cluster && docker logs mysqlgr1 | grep GROUP_NAME

--- a/cleanup_cluster.sh
+++ b/cleanup_cluster.sh
@@ -1,16 +1,16 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Stopping and removing the mysqlgr1 container..."
-docker stop mysqlgr1 >/dev/null 2>&1 && docker rm -v mysqlgr1 >/dev/null 2>&1
+docker stop mysqlgr1 >/dev/null 2>&1 && docker rm mysqlgr1 >/dev/null 2>&1
 
 echo "Stopping and removing the mysqlgr2 container..."
-docker stop mysqlgr2 >/dev/null 2>&1 && docker rm -v mysqlgr2 >/dev/null 2>&1
+docker stop mysqlgr2 >/dev/null 2>&1 && docker rm mysqlgr2 >/dev/null 2>&1
 
 echo "Stopping and removing the mysqlgr3 container..."
-docker stop mysqlgr3 >/dev/null 2>&1 && docker rm -v mysqlgr3 >/dev/null 2>&1
+docker stop mysqlgr3 >/dev/null 2>&1 && docker rm mysqlgr3 >/dev/null 2>&1
 
 echo "Stopping and removing the mysqlrouter1 container..."
-docker stop mysqlrouter1 >/dev/null 2>&1 && docker rm -v mysqlrouter1 >/dev/null 2>&1
+docker stop mysqlrouter1 >/dev/null 2>&1 && docker rm mysqlrouter1 >/dev/null 2>&1
 
 echo "Removing the grnet network..."
 docker network rm grnet >/dev/null 2>&1

--- a/cleanup_cluster.sh
+++ b/cleanup_cluster.sh
@@ -1,16 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "Stopping and removing the mysqlgr1 container..."
-docker stop mysqlgr1 >/dev/null 2>&1 && docker rm mysqlgr1 >/dev/null 2>&1
+docker stop mysqlgr1 >/dev/null 2>&1 && docker rm -v mysqlgr1 >/dev/null 2>&1
 
 echo "Stopping and removing the mysqlgr2 container..."
-docker stop mysqlgr2 >/dev/null 2>&1 && docker rm mysqlgr2 >/dev/null 2>&1
+docker stop mysqlgr2 >/dev/null 2>&1 && docker rm -v mysqlgr2 >/dev/null 2>&1
 
 echo "Stopping and removing the mysqlgr3 container..."
-docker stop mysqlgr3 >/dev/null 2>&1 && docker rm mysqlgr3 >/dev/null 2>&1
+docker stop mysqlgr3 >/dev/null 2>&1 && docker rm -v mysqlgr3 >/dev/null 2>&1
 
 echo "Stopping and removing the mysqlrouter1 container..."
-docker stop mysqlrouter1 >/dev/null 2>&1 && docker rm mysqlrouter1 >/dev/null 2>&1
+docker stop mysqlrouter1 >/dev/null 2>&1 && docker rm -v mysqlrouter1 >/dev/null 2>&1
 
 echo "Removing the grnet network..."
 docker network rm grnet >/dev/null 2>&1

--- a/innodb_cluster-entrypoint.sh
+++ b/innodb_cluster-entrypoint.sh
@@ -7,6 +7,11 @@ if [ "${1:0:1}" = '-' ]; then
         ARGS="$@"
 fi
 
+# If the password variable is a filename we use the contents of the file
+if [ -n "$MYSQL_ROOT_PASSWORD" -a -f "$MYSQL_ROOT_PASSWORD" ]; then
+	MYSQL_ROOT_PASSWORD="$(cat $MYSQL_ROOT_PASSWORD)"
+fi
+
 # If we're setting up a router 
 if [ "$NODE_TYPE" = 'router' ]; then
 
@@ -108,10 +113,6 @@ else
 			echo >&2 'error: database is uninitialized and password option is not specified '
 			echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD and MYSQL_RANDOM_ROOT_PASSWORD'
 			exit 1
-		fi
-		# If the password variable is a filename we use the contents of the file
-		if [ -f "$MYSQL_ROOT_PASSWORD" ]; then
-			MYSQL_ROOT_PASSWORD="$(cat $MYSQL_ROOT_PASSWORD)"
 		fi
 		mkdir -p "$DATADIR"
 		chown -R mysql:mysql "$DATADIR"


### PR DESCRIPTION
Note: this change, while pursuing some best practices, could result in more complexity in the project. Feel free to reject them if they seem too hard to maintain. The method is described in [A safer MySQL box in Docker](https://datacharmer.blogspot.com.es/2016/02/a-safer-mysql-box-in-docker.html).

- Added ability to define the image to run instead of the default one:
     export INNODB_CLUSTER_IMG=your_username/innodb-cluster

- The password is generated on the fly and stored in secretpassword.txt
  which is then added to the container as a volume file

- Fixed usage of MYSQL_ROOT_PASSWORD in entry point
When MYSQL_ROOT_PASSWORD is a file reference, it should be processed
before any usage of that variable. Moved the file usage up in the
evaluation chain.

- Added info on random password and custom image usage to README.md