### PR TITLE
Added testing scripts and improved testability 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN rpmkeys --import http://repo.mysql.com/RPM-GPG-KEY-mysql \
   && yum install -y $SHELL_URL \
   && yum install -y libpwquality \
   && yum install -y hostname \
+  && yum install -y less vim-minimal net-tools \
   && rm -rf /var/cache/yum/*
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/innodb_cluster-entrypoint.sh
+++ b/innodb_cluster-entrypoint.sh
@@ -67,7 +67,7 @@ else
 	fi
 
         # let's generate a random server_id value; it can be any unsigned 32 bit int
-        SERVER_ID=$((RANDOM % 1000))
+        [ -z "$SERVER_ID" ] && SERVER_ID=$((RANDOM % 1000))
 
         CMD="mysqld"
 

--- a/make_my_cnf.sh
+++ b/make_my_cnf.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo '[client]'   > ~/.my.cnf
+echo 'user=root' >> ~/.my.cnf
+echo -n 'password=' >> ~/.my.cnf
+cat /root/secretpassword.txt >> ~/.my.cnf
+

--- a/start_three_node_cluster.sh
+++ b/start_three_node_cluster.sh
@@ -51,8 +51,9 @@ function check_for_started_server
 
 # Allowing the cluster to use a random password instead of a predefined one
 SECRET_PWD_FILE=secretpassword.txt
-export docker_run="docker run --network=grnet -v $PWD/$SECRET_PWD_FILE:/root/$SECRET_PWD_FILE -e MYSQL_ROOT_PASSWORD=/root/$SECRET_PWD_FILE"
-#export docker_run="docker run --network=grnet -v $PWD/$SECRET_PWD_FILE:/root/$SECRET_PWD_FILE -e MYSQL_ROOT_PASSWORD=root"
+
+# Adding the current path as a volume (/opt/ic) in every node
+export docker_run="docker run --network=grnet -v $PWD/$SECRET_PWD_FILE:/root/$SECRET_PWD_FILE -e MYSQL_ROOT_PASSWORD=/root/$SECRET_PWD_FILE -v $PWD:/opt/ic"
 
 RANDOM_PASSWORD=$(echo $RANDOM | sha256sum | cut -c 1-16 )
 if [ -z "$RANDOM_PASSWORD" ] ; then
@@ -66,7 +67,8 @@ create_network grnet
 [ -z "$INNODB_CLUSTER_IMG" ] && INNODB_CLUSTER_IMG=mattalord/innodb-cluster
 
 echo "Bootstrapping the cluster..."
-$docker_run --name=mysqlgr1 --hostname=mysqlgr1 -e BOOTSTRAP=1 -itd $INNODB_CLUSTER_IMG
+params="-e SERVER_ID=100 --name=mysqlgr1 --hostname=mysqlgr1"
+$docker_run $params -e BOOTSTRAP=1 -itd $INNODB_CLUSTER_IMG
 
 check_for_failure mysqlgr1
 check_for_started_server mysqlgr1
@@ -75,13 +77,15 @@ echo "Getting GROUP_NAME..."
 GROUP_PARAM=$(docker logs mysqlgr1 | awk 'BEGIN {RS=" "}; /GROUP_NAME/')
 
 echo "Adding second node..."
-$docker_run --name=mysqlgr2 --hostname=mysqlgr2 -e $GROUP_PARAM -e GROUP_SEEDS="mysqlgr1:6606" -itd $INNODB_CLUSTER_IMG
+params="-e SERVER_ID=200 --name=mysqlgr2 --hostname=mysqlgr2"
+$docker_run $params -e $GROUP_PARAM -e GROUP_SEEDS="mysqlgr1:6606" -itd $INNODB_CLUSTER_IMG
 
 check_for_failure mysqlgr2
 check_for_started_server mysqlgr2
 
 echo "Adding third node..."
-$docker_run --name=mysqlgr3 --hostname=mysqlgr3 -e $GROUP_PARAM -e GROUP_SEEDS="mysqlgr1:6606" -itd $INNODB_CLUSTER_IMG
+params="-e SERVER_ID=300 --name=mysqlgr3 --hostname=mysqlgr3"
+$docker_run $params -e $GROUP_PARAM -e GROUP_SEEDS="mysqlgr1:6606" -itd $INNODB_CLUSTER_IMG
 
 check_for_failure mysqlgr3
 check_for_started_server mysqlgr3
@@ -92,7 +96,7 @@ echo "Sleeping $DELAY seconds to give the cluster time to sync up"
 sleep $DELAY
 
 echo "Adding a router..."
-$docker_run --name=mysqlrouter1 --hostname=mysqlrouter1 -e NODE_TYPE=router -e MYSQL_HOST=mysqlgr1 -itd $INNODB_CLUSTER_IMG
+$docker_run -e SERVER_ID=400 --name=mysqlrouter1 --hostname=mysqlrouter1 -e NODE_TYPE=router -e MYSQL_HOST=mysqlgr1 -itd $INNODB_CLUSTER_IMG
 check_for_failure mysqlrouter1
 
 echo "Done!"
@@ -105,4 +109,11 @@ echo
 (set -x
 docker exec -it mysqlgr1 mysqlsh --uri=root:$(cat $SECRET_PWD_FILE)@mysqlgr1:3306
 )
+
+# Allow using mysql without typing a password
+for node in gr1 gr2 gr3 router1 ; do
+    docker exec -it mysql$node /opt/ic/make_my_cnf.sh
+done
+
+
 exit

--- a/test_node.sh
+++ b/test_node.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+hostname=$(hostname)
+in_node=0
+for node in 1 2 3 ; do
+    if [ "$(hostname)" == "mysqlgr$node" ] ; then
+        in_node=1
+    fi
+done
+if [ "$in_node" == "0" ] ; then
+    
+    echo "# This command must run in one of the nodes"
+    echo "# e.g.: "
+    echo "# docker exec -it mysqlgr1 /opt/ic/test_nodes.sh"
+    exit 1
+fi
+if [ ! -f $HOME/.my.cnf ] ; then
+    echo "File $HOME/.my.cnf not found - aborting"
+    exit 1
+fi
+
+mysql="mysql -u root -h localhost --protocol=tcp "
+
+echo "# Node $hostname"
+$mysql -ve 'select * from performance_schema.replication_group_members\G'
+$mysql -ve 'select * from performance_schema.replication_group_member_stats\G'

--- a/test_nodes.sh
+++ b/test_nodes.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+for node in 1 2 3 ; do
+     docker exec -it mysqlgr$node /opt/ic/test_node.sh
+done

--- a/test_router.sh
+++ b/test_router.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+if [ "$(hostname)" != "mysqlrouter1" ] ; then
+    echo "# This command must run in the router"
+    echo "# e.g.: "
+    echo "# docker exec -it mysqlrouter1 /opt/ic/test_router.sh"
+    exit 1
+fi
+if [ ! -f $HOME/.my.cnf ] ; then
+    echo "File $HOME/.my.cnf not found - aborting"
+    exit 1
+fi
+
+mysql="mysql -u root -h localhost --protocol=tcp "
+
+echo "Server ID of current master"
+$mysql -P6446 -ve 'SELECT @@global.server_id'
+echo "Create content using router"
+$mysql -P6446 -ve 'create schema if not exists test'
+$mysql -P6446  test -ve 'drop table if exists t1'
+$mysql -P6446  test -ve 'create table t1(id int not null primary key, name varchar(50))'
+$mysql -P6446  test -ve 'insert into t1 values (1, "aaa")'
+
+sleep 3
+echo "Server ID of A RO node"
+$mysql -P6447 -ve 'SELECT @@global.server_id'
+echo "retrieving contents using router"
+$mysql -P6447 -ve 'SELECT * from test.t1'


### PR DESCRIPTION

* added packages in Dockerfile to improve container examination
* using dynamic server-id in innodb-cluster-entrypoint.sh (referenced from starting script)
* made the deployment easier to test (after deployment, a .my.cnf file is created to invoke mysql without using passwords on the CL)
* added testing scripts to see the status of the nodes and to test replication through the router.