### PR TITLE
Make check_for_started_server less verbose

### DIFF
--- a/start_three_node_cluster.sh
+++ b/start_three_node_cluster.sh
@@ -35,15 +35,18 @@ function check_for_started_server
 {
 	container_name=$1
 
-	for i in {60..0}; do
-		if docker logs $container_name | grep 'Ready for start up'; then
+	printf "Starting $container_name container..."
+	for i in {30..0}; do
+		if [[ $(docker logs $container_name) =~ "Ready for start up" ]]; then
+			echo " done."
 			break
 		fi
-		echo "Starting $container_name container..."
-		sleep 1
+		printf "."
+		sleep 2
 	done
 
 	if [ "$i" = 0 ]; then
+		echo
 		echo >&2 "Start of $container_name container failed."
 		exit 1
 	fi


### PR DESCRIPTION
This felt a bit verbose, so now instead of this:

> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> Starting mysqlgr1 container...
> MySQL init process done. Ready for start up.

We see something like this:

> Starting mysqlgr1 container............ done.

Where a single '.' is now added each time the docker log is checked for "Ready for start up".

Also, polling frequency changed from 1 to 2 seconds.

Note: if "MySQL init process done. Ready for start up." should remain then feel free to change it or request a new PR.