### PR TITLE
Have Router tests use secret password

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ This manual process essentially documents what the `start_three_node_cluster.sh`
 
 To test the `RW` port, which always goes to the PRIMARY node:
 
-  ```mysql -u root -proot -h localhost --protocol=tcp -P6446 -e 'SELECT @@global.server_uuid'```
+  ```mysql -u root -p$(cat $MYSQL_ROOT_PASSWORD) -h localhost --protocol=tcp -P6446 -e 'SELECT @@global.server_uuid'```
 
 To test the `RO` port, which is round-robin load balanced to the SECONDARY nodes:
 
-  ```mysql -u root -proot -h localhost --protocol=tcp -P6447 -e 'SELECT @@global.server_uuid'```
+  ```mysql -u root -p$(cat $MYSQL_ROOT_PASSWORD) -h localhost --protocol=tcp -P6447 -e 'SELECT @@global.server_uuid'```
 
 ---
 


### PR DESCRIPTION
Not sure if this is fully correct as it feels wrong, but it's working for me. In my test, $MYSQL_ROOT_PASSWORD equals the path to secretpassword.txt which is /root/secretpassword.txt in this case. Originally I assumed it'd contain secretpassword.txt's value.