### PR TITLE
Fix cat to echo

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ This manual process essentially documents what the `start_three_node_cluster.sh`
 
 To test the `RW` port, which always goes to the PRIMARY node:
 
-  ```mysql -u root -p$(cat $MYSQL_ROOT_PASSWORD) -h localhost --protocol=tcp -P6446 -e 'SELECT @@global.server_uuid'```
+  ```mysql -u root -p$(echo $MYSQL_ROOT_PASSWORD) -h localhost --protocol=tcp -P6446 -e 'SELECT @@global.server_uuid'```
 
 To test the `RO` port, which is round-robin load balanced to the SECONDARY nodes:
 
-  ```mysql -u root -p$(cat $MYSQL_ROOT_PASSWORD) -h localhost --protocol=tcp -P6447 -e 'SELECT @@global.server_uuid'```
+  ```mysql -u root -p$(echo $MYSQL_ROOT_PASSWORD) -h localhost --protocol=tcp -P6447 -e 'SELECT @@global.server_uuid'```
 
 ---
 


### PR DESCRIPTION
Following nested command actually fails:
```
mysql -u root -p$(cat $MYSQL_ROOT_PASSWORD) -h localhost --protocol=tcp -P6446 -e 'SELECT @@global.server_uuid'
cat: root: Is a directory
Enter password: 
+--------------------------------------+
| @@global.server_uuid                 |
+--------------------------------------+
| 4cc3047b-d62d-11e7-9330-0242ac120002 |
+--------------------------------------+
```
i.e. `$(cat $MYSQL_ROOT_PASSWORD)` its exit code is 1, but has to be 0, that's why it should be `echo` instead `cat`